### PR TITLE
Update documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Also in `run-settings` section you need to specify the path of your `spec.js` fi
 "specs": "./cypress/integration/1-getting-started/todo.spec.js"
 ```
 
-> In this demo, all occurences of http://localhost:8080 have been replaced with [https://example.cypress.io](https://example.cypress.io) to prevent running the Cypress tests locally. Alternatively, if you want to run your tests locally, refer to the [**Run Cypress tests locally**](https://www.lambdatest.com/support/docs/running-your-first-cypress-test/#running-your-cypress-tests-locally-on-lambdatest-platform) section below.
+> In this demo, all occurrences of http://localhost:8080 have been replaced with [https://example.cypress.io](https://example.cypress.io) to prevent running the Cypress tests locally. Alternatively, if you want to run your tests locally, refer to the [**Run Cypress tests locally**](https://www.lambdatest.com/support/docs/running-your-first-cypress-test/#running-your-cypress-tests-locally-on-lambdatest-platform) section below.
 
 3. Execute your tests using the following command in the terminal:
 
@@ -275,7 +275,7 @@ Visit the following links to learn more about LambdaTest's features, setup and t
 
 ## LambdaTest Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [LambdaTest Community](https://community.lambdatest.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practices in web development, testing, and DevOps with professionals from across the globe 🌎
 
 ## What's New At LambdaTest ❓
 

--- a/cypress-docs/parallel-testing.md
+++ b/cypress-docs/parallel-testing.md
@@ -1,13 +1,13 @@
 ## Run Your Cypress Tests In Parallel On LambdaTest Platform
 ***
     
-If you want to run your tests parallelly on the LambdaTest platform, you can do that using either of the following two ways:
+If you want to run your tests in parallel on the LambdaTest platform, you can do that using either of the following two ways:
 
-### 1. Run your Cypress tests Parallelly using the CLI
+### 1. Run your Cypress tests in Parallel using the CLI
 
 ---
 
-To perform Cypress testing parallelly using the CLI, you need to use the "`--parallels`" option while running your tests.
+To perform Cypress testing in parallel using the CLI, you need to use the "`--parallels`" option while running your tests.
 
 **Syntax:**
 
@@ -21,11 +21,11 @@ For example, if you want to run your Cypress tests on 5 parallel sessions, you c
 lambdatest-cypress run --parallels 5
 ```
 
-### 2. Run your Cypress tests Parallelly using the configuration.json file
+### 2. Run your Cypress tests in Parallel using the configuration.json file
 
 ---
 
-To run your Cypress testing parallelly, you can also use the **configuration.json** file, using the '**parallels**' key. **Syntax:**
+To run your Cypress testing in parallel, you can also use the **configuration.json** file, using the '**parallels**' key. **Syntax:**
 
 ```json
 {
@@ -49,5 +49,5 @@ For example, if you want to run your Cypress tests on 5 parallel sessions, use t
 }
 ```
 
-> The number of parallel test running on the LambdaTest platform at a time, is based on the concurrency plan of your LambdaTest account. In case the number of parallel tests is more than the concurrency plan, the remaining tests will get queued and run after the existing tests are complete. For example, suppose you have a concurrency plan of 5 parallel sessions and want to run 50 tests parallelly. In this case, only 5 parallel tests will be executed at a time, and the rest 45 will be queued. As the test finishes running, the queued tests will be moved to the running state based on availability.
+> The number of parallel test running on the LambdaTest platform at a time, is based on the concurrency plan of your LambdaTest account. In case the number of parallel tests is more than the concurrency plan, the remaining tests will get queued and run after the existing tests are complete. For example, suppose you have a concurrency plan of 5 parallel sessions and want to run 50 tests in parallel. In this case, only 5 parallel tests will be executed at a time, and the rest 45 will be queued. As the test finishes running, the queued tests will be moved to the running state based on availability.
     


### PR DESCRIPTION
Updated overall README.md and parallel testing documentation pages with minor fixes for typos and replaced all instances of `parallelly` with `in parallel` for improved readability and consistency. 