### PR TITLE
rebrand: Update README for TestMu AI rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,9 @@ The [TestMu AI Community](https://community.testmuai.com/) allows people to inte
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
       
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -303,14 +303,18 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)
 
 ## We are here to help you :headphones:
 

--- a/README.md
+++ b/README.md
@@ -299,13 +299,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
-# Run Cypress Tests On LambdaTest ![cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)
+# Run Cypress Tests — TestMu AI (Formerly LambdaTest)
+![cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)
 
 <img height="500" class ="centre" src="https://user-images.githubusercontent.com/70570645/171032160-65d8a2c3-e04b-482d-b1c6-538b75be5fb0.png">
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to get started with Cypress testing on the LambdaTest platform 🚀*
+*Learn how to get started with Cypress testing on the TestMu AI platform 🚀*
 
 [<img height="70" width="220" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+
 
 ## Table of Contents 🗏
 
 
 * [Pre-requisites](#pre-requisites)
-* [Running Your First Cypress Test On LambdaTest Platform](#running-your-first-cypress-test-on-lambdatest)
+* [Running Your First Cypress Test On TestMu AI Platform](#running-your-first-cypress-test-on-lambdatest)
 * [Local Testing With Cypress](#running-your-cypress-tests-locally)
 * [Authentication](#authentication)
 * [Cypress Parallel Testing](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/parallel-testing.md)
@@ -36,61 +38,63 @@
 * [Cypress CLI Commands](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/cypress-cli.md)
 * [Run Settings](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/run-settings.md)
 * [Download Artefact For Cypress Project](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/download-artefacts.md)
-* [Integrate LambdaTest With Cypress Dashboard](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/cypress-dashboard.md)
+* [Integrate TestMu AI With Cypress Dashboard](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/cypress-dashboard.md)
 * [Execute Cypress Tests Including Private Dependencies](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/dependencies.md)
 * [Applitools Integration For Cypress](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/applitools-integration.md)
-* [ReportPortal.io Integration With LambdaTest For Cypress](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/reportportalio-integration.md)
+* [ReportPortal.io Integration With TestMu AI For Cypress](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/reportportalio-integration.md)
+
 
 
 ## Pre-requisites
 
-Before we get started, make sure to clone the LambdaTest Cypress Cloud Repo. You can run your first Cypress test on the LambdaTest platform in a few simple steps:
+Before we get started, make sure to clone the TestMu AI Cypress Cloud Repo. You can run your first Cypress test on the TestMu AI platform in a few simple steps:
 
-- **Step 1:** Clone the LambdaTest-Cypress Cloud repo and navigate to the cloned directory.
+- **Step 1:** Clone the TestMu AI-Cypress Cloud repo and navigate to the cloned directory.
 
   ```bash
   git clone https://github.com/LambdaTest/Cypress-Cloud
   cd Cypress-Cloud
   ```
 
-- **Step 2: Installing the LambdaTest CLI -**
-  You need to install the **LambdaTest-Cypress CLI** package with the help of npm, using the below command:
+- **Step 2: Installing the TestMu AI CLI -**
+  You need to install the **TestMu AI-Cypress CLI** package with the help of npm, using the below command:
 
   ```bash
   npm install -g lambdatest-cypress-cli
   ```
 
 - **Step 3: Setup configurations on which you want to run your test -**
-  Once you have installed the LambdaTest-Cypress CLI, now you need to setup the configuration. You can do that using the below command:
+  Once you have installed the TestMu AI-Cypress CLI, now you need to setup the configuration. You can do that using the below command:
 
   ```bash
   lambdatest-cypress init
   ```
-## Running Your First Cypress Test On LambdaTest
+
+## Running Your First Cypress Test On TestMu AI
 
 
->**Test Scenario**: To demonstrate Cypress testing on LambdaTest, we will use the Cypress Kitchen Sink Example.
+>**Test Scenario**: To demonstrate Cypress testing on TestMu AI, we will use the Cypress Kitchen Sink Example.
 
-1.  Clone the LambdaTest Cypress Cloud GitHub repo and switch to the cloned directory.
+1.  Clone the TestMu AI Cypress Cloud GitHub repo and switch to the cloned directory.
 
 ```bash
 git clone https://github.com/LambdaTest/Cypress-Cloud
 cd Cypress-Cloud
 ```
 
-2.  Setup the **LambdaTest-Cypress CLI** and configure the configuration file, as shown in the pre-requisites before. A file named `lambdatest-config.json` is generated in your project using the below command:
+2.  Setup the **TestMu AI-Cypress CLI** and configure the configuration file, as shown in the pre-requisites before. A file named `lambdatest-config.json` is generated in your project using the below command:
 
 ```bash
 lambdatest-cypress init
 ```
 
-Here, we have used the below configuration as default and generated it in the `lambdatest-config.json` file. You need to set up the authentication by using LambdaTest credentials. You can check the [Authentication documentation](https://www.lambdatest.com/support/docs/authentication) for more details about authentication.
+Here, we have used the below configuration as default and generated it in the `lambdatest-config.json` file. You need to set up the authentication by using TestMu AI credentials. You can check the [Authentication documentation](https://www.testmuai.com/support/docs/authentication) for more details about authentication.
 
 ```json
 {
   "lambdatest_auth": {
     "username": "<YOUR_LAMBDATEST_USERNAME>",
-    "access_key": "<Your LambdaTest access key>"
+    "access_key": "<Your TestMu AI access key>"
   },
   "browsers": [
     {
@@ -128,7 +132,7 @@ Also in `run-settings` section you need to specify the path of your `spec.js` fi
 "specs": "./cypress/integration/examples/*.spec.js"
 ```
 
-> In this demo, all occurrences of http://localhost:8080 have been replaced with [https://example.cypress.io](https://example.cypress.io) to prevent running the Cypress tests locally. Alternatively, if you want to run your tests locally, refer to the [**Run Cypress tests locally**](https://www.lambdatest.com/support/docs/running-your-first-cypress-test/#running-your-cypress-tests-locally-on-lambdatest-platform) section below.
+> In this demo, all occurrences of http://localhost:8080 have been replaced with [https://example.cypress.io](https://example.cypress.io) to prevent running the Cypress tests locally. Alternatively, if you want to run your tests locally, refer to the [**Run Cypress tests locally**](https://www.testmuai.com/support/docs/running-your-first-cypress-test/#running-your-cypress-tests-locally-on-lambdatest-platform) section below.
 
 3. Execute your tests using the following command in the terminal:
 
@@ -136,25 +140,27 @@ Also in `run-settings` section you need to specify the path of your `spec.js` fi
 lambdatest-cypress run
 ```
 
+
 ## View Your Cypress Testing Result
 
 
-As soon as the tests starts executing, you can view them running. Visit your LambdaTest Automation Dashboard.
+As soon as the tests starts executing, you can view them running. Visit your TestMu AI Automation Dashboard.
 
 
 <img height="400" src="https://user-images.githubusercontent.com/70570645/169592614-d41ad246-32c5-46e1-935c-6f0101f467e6.png">
 
-For each test, you can view the live video feed, screenshots for each test run, console logs, terminal logs and do much more using the **LambdaTest platform**.
+For each test, you can view the live video feed, screenshots for each test run, console logs, terminal logs and do much more using the **TestMu AI platform**.
 
 If the test gets executed successfully, you will see a green tick on the Timeline view and a "Completed" message on the Automation logs view of your Automation dashboard. If not, then you will see a red cross and a "Failed" message respectively.
       
 <img height="400" src="https://user-images.githubusercontent.com/70570645/169593512-94f845b7-3bcc-40f8-a5c1-0c9ab872e3ff.png">
 
 
+
 ## Running Your Cypress Tests Locally
 
 
-To run your tests locally on the LambdaTest platform, you need to setup LambdaTest tunnel, and execute commands using the CLI, or [download UnderPass](https://downloads.lambdatest.com/underpass/master/UnderPass%20Setup.exe), our GUI based desktop app. Once you have the LambdaTest tunnel or Underpass set up and started, you can use the LambdaTest platform to run your Cypress tests locally.
+To run your tests locally on the TestMu AI platform, you need to setup TestMu AI tunnel, and execute commands using the CLI, or [download UnderPass](https://downloads.lambdatest.com/underpass/master/UnderPass%20Setup.exe), our GUI based desktop app. Once you have the TestMu AI tunnel or Underpass set up and started, you can use the TestMu AI platform to run your Cypress tests locally.
 
 Now you need to activate the tunnel capability in the lambdatest_config.json file under the section "connection_settings" as shown below:
 
@@ -165,7 +171,8 @@ Now you need to activate the tunnel capability in the lambdatest_config.json fil
   },
 ```
 
-You can provide the name of the **LambdaTest tunnel** as per your requirements.
+You can provide the name of the **TestMu AI tunnel** as per your requirements.
+
 
 ## Authentication
 
@@ -186,8 +193,8 @@ The following args can be used while running tests using the run command.
 
 | Arg        | Shorthand | Accepted values            |
 | ---------- | --------- | -------------------------- |
-| --username | -u        | Your LambdaTest username   |
-| --access_key      | -k        | Your LambdaTest access key |
+| --username | -u        | Your TestMu AI username   |
+| --access_key      | -k        | Your TestMu AI access key |
 
 For example -
 
@@ -197,7 +204,7 @@ For example -
 
 ### Using lambdatest-config.json:
 
-The auth option will help you in specifying your username and access key. You can find your username and access key in the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/build). Both, the auth credentials set in environment variables and the ones mentioned in the lambdatest-config.json file will get overridden.
+The auth option will help you in specifying your username and access key. You can find your username and access key in the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build). Both, the auth credentials set in environment variables and the ones mentioned in the lambdatest-config.json file will get overridden.
       
 <img height="400" src="https://user-images.githubusercontent.com/70570645/169593640-9672bc33-49c1-4abe-8887-645a33defab7.png">
 
@@ -206,8 +213,8 @@ The options supported in the auth are as follows:
 
 | Arg        | Accepted values            |
 | ---------- | -------------------------- |
-| username   | Your LambdaTest username   |
-| access_key | Your LambdaTest access key |
+| username   | Your TestMu AI username   |
+| access_key | Your TestMu AI access key |
 
 For example -
 
@@ -224,8 +231,8 @@ While utilizing the CLI params, you can set up the following environment variabl
 
 | Env variable  | Accepted values            |
 | ------------- | -------------------------- |
-| LT_USERNAME   | Your LambdaTest username   |
-| LT_ACCESS_KEY | Your LambdaTest access key |
+| LT_USERNAME   | Your TestMu AI username   |
+| LT_ACCESS_KEY | Your TestMu AI access key |
 
 Or you can also set environment variables using following commands:
 
@@ -244,67 +251,68 @@ set LT_USERNAME="YOUR_USERNAME" set LT_ACCESS_KEY="YOUR ACCESS KEY"
 > **Note** - By doing so, the auth credentials you use in your lambdatest-config.json file will get overridden only if these options are not provided in lambdatest-config.json.<br>
 
 
+
 ## Tutorials 📙
 
 Check out our latest tutorials on Cypress automation testing 👇
 
-* [Cypress Vs Selenium: Which is Better in 2022?](https://www.lambdatest.com/blog/cypress-vs-selenium-comparison/)
-* [Introduction to Cypress Test Automation Framework](https://www.lambdatest.com/blog/cypress-test-automation-framework/)
-* [Scalable and Reliable Cross Browser Testing with Cypress](https://www.lambdatest.com/blog/cross-browser-testing-with-cypress-framework/)
-* [Now Run Your Cypress Tests on LambdaTest](https://www.lambdatest.com/blog/cypress-cli-on-lambdatest/)
-* [How to Perform Cypress Testing at Scale with LambdaTest](https://www.lambdatest.com/blog/how-to-perform-cypress-testing-at-scale-with-lambdatest/)
-* [Complete Guide to Cypress Visual Regression Testing](https://www.lambdatest.com/blog/cypress-visual-regression-testing/)
-* [How to Fill and Submit Forms in Cypress](https://www.lambdatest.com/blog/fill-and-submit-forms-in-cypress/)
-* [How to Find HTML Elements Using Cypress Locators](https://www.lambdatest.com/blog/finding-html-elements-using-cypress-locators/)
-* [Handling Touch and Mouse Events in Cypress [Tutorial]](https://www.lambdatest.com/blog/handling-touch-and-mouse-events-in-cypress/)
-* [How to Find Broken Links using Cypress [With Examples]](https://www.lambdatest.com/blog/find-broken-links-using-cypress/)
-* [Web Performance Testing with Cypress and Google Lighthouse](https://www.lambdatest.com/blog/using-cypress-google-lighthouse-performance-testing/)
+* [Cypress Vs Selenium: Which is Better in 2022?](https://www.testmuai.com/blog/cypress-vs-selenium-comparison/)
+* [Introduction to Cypress Test Automation Framework](https://www.testmuai.com/blog/cypress-test-automation-framework/)
+* [Scalable and Reliable Cross Browser Testing with Cypress](https://www.testmuai.com/blog/cross-browser-testing-with-cypress-framework/)
+* [Now Run Your Cypress Tests on TestMu AI](https://www.testmuai.com/blog/cypress-cli-on-lambdatest/)
+* [How to Perform Cypress Testing at Scale with TestMu AI](https://www.testmuai.com/blog/how-to-perform-cypress-testing-at-scale-with-lambdatest/)
+* [Complete Guide to Cypress Visual Regression Testing](https://www.testmuai.com/blog/cypress-visual-regression-testing/)
+* [How to Fill and Submit Forms in Cypress](https://www.testmuai.com/blog/fill-and-submit-forms-in-cypress/)
+* [How to Find HTML Elements Using Cypress Locators](https://www.testmuai.com/blog/finding-html-elements-using-cypress-locators/)
+* [Handling Touch and Mouse Events in Cypress [Tutorial]](https://www.testmuai.com/blog/handling-touch-and-mouse-events-in-cypress/)
+* [How to Find Broken Links using Cypress [With Examples]](https://www.testmuai.com/blog/find-broken-links-using-cypress/)
+* [Web Performance Testing with Cypress and Google Lighthouse](https://www.testmuai.com/blog/using-cypress-google-lighthouse-performance-testing/)
 
 For video tutorials on Cypress testing, please refer to our [Cypress Testing Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPnxrxi544nL1vdC1noooXPx). ▶️
 
-Subscribe To Our [LambdaTest YouTube Channel 🔔](https://www.youtube.com/c/LambdaTest) and keep up-to-date on the latest video tutorial around Cypress.
+Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around Cypress.
+
 
 ## Documentation & Resources :books:
 
       
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)    
 
-## LambdaTest Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practices in web development, testing, and DevOps with professionals from across the globe 🌎
+## TestMu AI Community :busts_in_silhouette:
 
-## What's New At LambdaTest ❓
+The [TestMu AI Community](https://community.testmuai.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practices in web development, testing, and DevOps with professionals from across the globe 🌎
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
+
+## What's New At TestMu AI ❓
+
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
       
-## About LambdaTest
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-    
-[<img height="70" width="220" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+**🔄 Our Rebrand Journey**
 
-      
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
 ## We are here to help you :headphones:
 
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
+* Got a query? we are available 24x7 to help. [Contact Us](support@testmuai.com)
+* For more info, visit - [TestMu AI](https://www.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)

--- a/README.md
+++ b/README.md
@@ -1,328 +1,114 @@
-# Run Cypress Tests — TestMu AI (Formerly LambdaTest)
-![cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)
-
-<img height="500" class ="centre" src="https://user-images.githubusercontent.com/70570645/171032160-65d8a2c3-e04b-482d-b1c6-538b75be5fb0.png">
+# Run Cypress Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/cypress"><img src="https://img.shields.io/npm/v/cypress.svg?style=for-the-badge&labelColor=000000" alt="Cypress version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to get started with Cypress testing on the TestMu AI platform 🚀*
+## Getting Started
 
-[<img height="70" width="220" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks.
 
+With TestMu AI (Formerly LambdaTest), you can run Cypress automation tests on a scalable cloud browser grid using the LambdaTest Cypress CLI. This sample shows how to configure Cypress to run on the TestMu AI cloud.
 
-## Table of Contents 🗏
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/getting-started-with-cypress-testing/) for the full setup walkthrough.
 
+### Prerequisites
 
-* [Pre-requisites](#pre-requisites)
-* [Running Your First Cypress Test On TestMu AI Platform](#running-your-first-cypress-test-on-lambdatest)
-* [Local Testing With Cypress](#running-your-cypress-tests-locally)
-* [Authentication](#authentication)
-* [Cypress Parallel Testing](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/parallel-testing.md)
-* [Specify Browsers And OS](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/supported-browsers-os.md)
-* [Supported Cypress Versions](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/supported-cypress-versions.md)
-* [Cypress CLI Commands](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/cypress-cli.md)
-* [Run Settings](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/run-settings.md)
-* [Download Artefact For Cypress Project](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/download-artefacts.md)
-* [Integrate TestMu AI With Cypress Dashboard](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/cypress-dashboard.md)
-* [Execute Cypress Tests Including Private Dependencies](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/dependencies.md)
-* [Applitools Integration For Cypress](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/applitools-integration.md)
-* [ReportPortal.io Integration With TestMu AI For Cypress](https://github.com/LambdaTest/Cypress-Cloud/blob/master/cypress-docs/reportportalio-integration.md)
+- Node.js 12 or higher
+- npm
+- Cypress
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
+### Setup
 
-
-## Pre-requisites
-
-Before we get started, make sure to clone the TestMu AI Cypress Cloud Repo. You can run your first Cypress test on the TestMu AI platform in a few simple steps:
-
-- **Step 1:** Clone the TestMu AI-Cypress Cloud repo and navigate to the cloned directory.
-
-  ```bash
-  git clone https://github.com/LambdaTest/Cypress-Cloud
-  cd Cypress-Cloud
-  ```
-
-- **Step 2: Installing the TestMu AI CLI -**
-  You need to install the **TestMu AI-Cypress CLI** package with the help of npm, using the below command:
-
-  ```bash
-  npm install -g lambdatest-cypress-cli
-  ```
-
-- **Step 3: Setup configurations on which you want to run your test -**
-  Once you have installed the TestMu AI-Cypress CLI, now you need to setup the configuration. You can do that using the below command:
-
-  ```bash
-  lambdatest-cypress init
-  ```
-
-## Running Your First Cypress Test On TestMu AI
-
-
->**Test Scenario**: To demonstrate Cypress testing on TestMu AI, we will use the Cypress Kitchen Sink Example.
-
-1.  Clone the TestMu AI Cypress Cloud GitHub repo and switch to the cloned directory.
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/Cypress-Cloud
-cd Cypress-Cloud
-```
-
-2.  Setup the **TestMu AI-Cypress CLI** and configure the configuration file, as shown in the pre-requisites before. A file named `lambdatest-config.json` is generated in your project using the below command:
-
-```bash
+git clone https://github.com/LambdaTest/Cypress-Cloud && cd Cypress-Cloud
+npm install -g lambdatest-cypress-cli
 lambdatest-cypress init
 ```
 
-Here, we have used the below configuration as default and generated it in the `lambdatest-config.json` file. You need to set up the authentication by using TestMu AI credentials. You can check the [Authentication documentation](https://www.testmuai.com/support/docs/authentication) for more details about authentication.
+Set your credentials as environment variables.
 
-```json
-{
-  "lambdatest_auth": {
-    "username": "<YOUR_LAMBDATEST_USERNAME>",
-    "access_key": "<Your TestMu AI access key>"
-  },
-  "browsers": [
-    {
-      "browser": "Chrome",
-      "platform": "Windows 10",
-      "versions": ["latest"]
-    },
-    {
-      "browser": "Firefox",
-      "platform": "Windows 10",
-      "versions": ["latest"]
-    }
-  ],
-  "run_settings": {
-    "cypress_config_file": "cypress.json",
-    "build_name": "build-name",
-    "parallels": 1,
-    "specs": "./*.spec.js",
-    "ignore_files": "",
-    "npm_dependencies": {
-      "cypress": "9.1.0"
-    },
-    "feature_file_suppport": false
-  },
-  "tunnel_settings": {
-    "tunnel": false,
-    "tunnelName": null
-  }
-}
+**macOS / Linux:**
+
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-Also in `run-settings` section you need to specify the path of your `spec.js` file on which you want to run the test on. Here we will pass the path of a **all examples** spec.js file for our demo.
+**Windows:**
 
-```json
-"specs": "./cypress/integration/examples/*.spec.js"
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-> In this demo, all occurrences of http://localhost:8080 have been replaced with [https://example.cypress.io](https://example.cypress.io) to prevent running the Cypress tests locally. Alternatively, if you want to run your tests locally, refer to the [**Run Cypress tests locally**](https://www.testmuai.com/support/docs/running-your-first-cypress-test/#running-your-cypress-tests-locally-on-lambdatest-platform) section below.
-
-3. Execute your tests using the following command in the terminal:
+### Run tests
 
 ```bash
 lambdatest-cypress run
 ```
 
+View results on your TestMu AI dashboard.
 
-## View Your Cypress Testing Result
+### Local testing with TestMu AI Tunnel
 
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-As soon as the tests starts executing, you can view them running. Visit your TestMu AI Automation Dashboard.
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
+Add the following to your capabilities:
 
-<img height="400" src="https://user-images.githubusercontent.com/70570645/169592614-d41ad246-32c5-46e1-935c-6f0101f467e6.png">
-
-For each test, you can view the live video feed, screenshots for each test run, console logs, terminal logs and do much more using the **TestMu AI platform**.
-
-If the test gets executed successfully, you will see a green tick on the Timeline view and a "Completed" message on the Automation logs view of your Automation dashboard. If not, then you will see a red cross and a "Failed" message respectively.
-      
-<img height="400" src="https://user-images.githubusercontent.com/70570645/169593512-94f845b7-3bcc-40f8-a5c1-0c9ab872e3ff.png">
-
-
-
-## Running Your Cypress Tests Locally
-
-
-To run your tests locally on the TestMu AI platform, you need to setup TestMu AI tunnel, and execute commands using the CLI, or [download UnderPass](https://downloads.lambdatest.com/underpass/master/UnderPass%20Setup.exe), our GUI based desktop app. Once you have the TestMu AI tunnel or Underpass set up and started, you can use the TestMu AI platform to run your Cypress tests locally.
-
-Now you need to activate the tunnel capability in the lambdatest_config.json file under the section "connection_settings" as shown below:
-
-```json
-  "connection_settings": {
-    "tunnel": true,
-    "tunnel_name": "lt-cypress-tunnel"
-  },
+```js
+tunnel: true,
 ```
 
-You can provide the name of the **TestMu AI tunnel** as per your requirements.
+## Contributions
 
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Cypress version.
 
-## Authentication
+## TestMu AI (Formerly LambdaTest) Community
 
-    
-Authenticate your Cypress test runs in the following ways -
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
 
-1. Set up the **environment variables**. (or)
-2. Utilizing the **CLI params**. (or)
-3. Mention yourusername and access key in the **lambdatest-config.json**.
+## TestMu AI (Formerly LambdaTest) Certifications
 
-> **Warning:** We use the following order of precedence to determine which auth credentials to use if you use more than one option to pass your auth credentials:
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-CLI arguments > Options set in lambdatest-config.json > Environment variables
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-### Utilizing CLI Params:
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-The following args can be used while running tests using the run command.
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
 
-| Arg        | Shorthand | Accepted values            |
-| ---------- | --------- | -------------------------- |
-| --username | -u        | Your TestMu AI username   |
-| --access_key      | -k        | Your TestMu AI access key |
+## LambdaTest is Now TestMu AI
 
-For example -
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-```bash
- lambdatest-cypress run --username YOUR_USERNAME --access_key YOUR_ACCESS_KEY
-```
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-### Using lambdatest-config.json:
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-The auth option will help you in specifying your username and access key. You can find your username and access key in the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build). Both, the auth credentials set in environment variables and the ones mentioned in the lambdatest-config.json file will get overridden.
-      
-<img height="400" src="https://user-images.githubusercontent.com/70570645/169593640-9672bc33-49c1-4abe-8887-645a33defab7.png">
+### How LambdaTest Evolved into TestMu AI
 
-      
-The options supported in the auth are as follows:
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-| Arg        | Accepted values            |
-| ---------- | -------------------------- |
-| username   | Your TestMu AI username   |
-| access_key | Your TestMu AI access key |
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-For example -
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm.
 
-```json
-"lambdatest_auth": {
-      "username": "<your username>",
-      "access_key": "<your access key>"
-   },
-```
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-### Setup the Environment Variables:
+## Support
 
-While utilizing the CLI params, you can set up the following environment variables.
-
-| Env variable  | Accepted values            |
-| ------------- | -------------------------- |
-| LT_USERNAME   | Your TestMu AI username   |
-| LT_ACCESS_KEY | Your TestMu AI access key |
-
-Or you can also set environment variables using following commands:
-
-- For **Linux/macOS**:
-
-```bash
-export LT_USERNAME="YOUR_USERNAME" export LT_ACCESS_KEY="YOUR ACCESS KEY"
-```
-
-- For **Windows**:
-
-```bash
-set LT_USERNAME="YOUR_USERNAME" set LT_ACCESS_KEY="YOUR ACCESS KEY"
-```
-      
-> **Note** - By doing so, the auth credentials you use in your lambdatest-config.json file will get overridden only if these options are not provided in lambdatest-config.json.<br>
-
-
-
-## Tutorials 📙
-
-Check out our latest tutorials on Cypress automation testing 👇
-
-* [Cypress Vs Selenium: Which is Better in 2022?](https://www.testmuai.com/blog/cypress-vs-selenium-comparison/)
-* [Introduction to Cypress Test Automation Framework](https://www.testmuai.com/blog/cypress-test-automation-framework/)
-* [Scalable and Reliable Cross Browser Testing with Cypress](https://www.testmuai.com/blog/cross-browser-testing-with-cypress-framework/)
-* [Now Run Your Cypress Tests on TestMu AI](https://www.testmuai.com/blog/cypress-cli-on-lambdatest/)
-* [How to Perform Cypress Testing at Scale with TestMu AI](https://www.testmuai.com/blog/how-to-perform-cypress-testing-at-scale-with-lambdatest/)
-* [Complete Guide to Cypress Visual Regression Testing](https://www.testmuai.com/blog/cypress-visual-regression-testing/)
-* [How to Fill and Submit Forms in Cypress](https://www.testmuai.com/blog/fill-and-submit-forms-in-cypress/)
-* [How to Find HTML Elements Using Cypress Locators](https://www.testmuai.com/blog/finding-html-elements-using-cypress-locators/)
-* [Handling Touch and Mouse Events in Cypress [Tutorial]](https://www.testmuai.com/blog/handling-touch-and-mouse-events-in-cypress/)
-* [How to Find Broken Links using Cypress [With Examples]](https://www.testmuai.com/blog/find-broken-links-using-cypress/)
-* [Web Performance Testing with Cypress and Google Lighthouse](https://www.testmuai.com/blog/using-cypress-google-lighthouse-performance-testing/)
-
-For video tutorials on Cypress testing, please refer to our [Cypress Testing Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPnxrxi544nL1vdC1noooXPx). ▶️
-
-Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around Cypress.
-
-
-## Documentation & Resources :books:
-
-      
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
-
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)    
-
-
-## TestMu AI Community :busts_in_silhouette:
-
-The [TestMu AI Community](https://community.testmuai.com/) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practices in web development, testing, and DevOps with professionals from across the globe 🌎
-
-
-## What's New At TestMu AI ❓
-
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
-      
-
-## 🚀 LambdaTest is Now TestMu AI
-
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
-
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
-
-### 🔄 Our Rebrand Journey
-
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
-
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
-
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
-
-## We are here to help you :headphones:
-
-* Got a query? we are available 24x7 to help. [Contact Us](support@testmuai.com)
-* For more info, visit - [TestMu AI](https://www.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=cypress-cloud)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
## Summary
- Replaced all LambdaTest references with TestMu AI in prose and links
- Updated H1 heading with TestMu AI suffix using em dash
- Added LambdaTest is Now TestMu AI rebrand section
- Updated YouTube link to @TestMuAI and community URL to testmuai.com

Generated with Claude Code